### PR TITLE
Fix plugin import path handling on Windows

### DIFF
--- a/runtime/src/main/java/com/google/cloud/verticals/foundations/dataharmonization/Main.java
+++ b/runtime/src/main/java/com/google/cloud/verticals/foundations/dataharmonization/Main.java
@@ -109,7 +109,8 @@ public final class Main {
         inputData.put(outputDir.resolve("default.json"), NullData.instance);
       }
 
-      Path mappingPath = FileSystems.getDefault().getPath(cmd.getOptionValue("m"));
+      Path mappingPath =
+          FileSystems.getDefault().getPath(cmd.getOptionValue("m")).toAbsolutePath().normalize();
       ImportPath mappingImportPath =
           ImportPath.of(FileLoader.NAME, mappingPath, mappingPath.getParent());
 

--- a/runtime/src/main/java/com/google/cloud/verticals/foundations/dataharmonization/imports/ImportPath.java
+++ b/runtime/src/main/java/com/google/cloud/verticals/foundations/dataharmonization/imports/ImportPath.java
@@ -153,7 +153,14 @@ public final class ImportPath implements Serializable {
 
   @Override
   public String toString() {
-    return String.format("%s://%s", loader, absolutePath);
+    String path = absolutePath == null ? "" : absolutePath.toString().replace('\\', '/');
+    if (!"file".equals(loader) && path.matches("^[A-Za-z]:/.*")) {
+      path = path.substring(2);
+    }
+    if (!path.startsWith("/")) {
+      path = "/" + path;
+    }
+    return String.format("%s://%s", loader, path);
   }
 
   public Path getImportsRoot() {

--- a/transpiler/src/main/java/com/google/cloud/verticals/foundations/dataharmonization/Transpiler.java
+++ b/transpiler/src/main/java/com/google/cloud/verticals/foundations/dataharmonization/Transpiler.java
@@ -1040,7 +1040,10 @@ public class Transpiler extends WhistleBaseVisitor<AbstractMessage> {
     }
 
     URI uri = URI.create(fileInfo.getUrl());
-    Path path = FileSystems.getDefault().getPath(uri.getPath());
+    Path path =
+        "file".equals(uri.getScheme())
+            ? Path.of(uri)
+            : FileSystems.getDefault().getPath(uri.getPath());
     String name = path.getFileName().toString();
     return name.contains(".") ? name.substring(0, name.lastIndexOf('.')) : name;
   }

--- a/transpiler/src/main/java/com/google/cloud/verticals/foundations/dataharmonization/data/Packages.java
+++ b/transpiler/src/main/java/com/google/cloud/verticals/foundations/dataharmonization/data/Packages.java
@@ -22,6 +22,9 @@ public final class Packages {
   public static final ImmutableMap<String, String> ALIAS =
       ImmutableMap.<String, String>builder()
           .put(
+              "logging",
+              "class://com.google.cloud.verticals.foundations.dataharmonization.plugins.logging.LoggingPlugin")
+          .put(
               "test",
               "class://com.google.cloud.verticals.foundations.dataharmonization.plugins.test.TestPlugin")
           .buildOrThrow();


### PR DESCRIPTION
## Summary

Fixes plugin import handling for Windows paths and documented logging imports.

This PR addresses path-related failures reported when importing plugins from Whistle files on Windows. It normalizes CLI mapping paths before deriving the import root, emits stable URL-style import path strings, and parses `file://` URIs correctly in the transpiler. It also adds the missing `logging` alias so the documented `import "logging"` form resolves to the logging plugin class.

Fixes #78

## Changes

- Normalize CLI mapping paths in `Main` before creating the root `ImportPath`.
- Format `ImportPath.toString()` with forward slashes for stable URI-like output.
- Parse `file://` URIs with `Path.of(uri)` in the transpiler to support Windows file paths.
- Add `logging` to the Whistle package alias map.

## Verification

- Ran:
  ```powershell
  gradle :transpiler:compileJava :runtime:compileJava
  ```
- Smoke-tested a Whistle file using:
  ```wstl
  import "logging"
  ```
  through `quickrun`; it completed successfully and produced the expected output.